### PR TITLE
feat: type enforcers

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,28 @@ willBeStringSomehow('someone'); // 'someone'
 willBeStringSomehow([someone]); // 'oops: [object Object]'
 ```
 
+You can also use the curried type ensurer to map values:
+
+```typescript
+const mustBeString = ensure(isString, 'oops');
+const willBeString = ensure(isString).orElse('none');
+const willBeStringLazily = ensure(isString).orGet(() => 'none, but late');
+const willBeStringSomehow = ensure(isString).orMap(value => `oops: ${String(value)}`);
+
+const someNames = ['simba', new Lion('nala')];
+const allNames = ['simba', 'nala'];
+
+allNames.map(mustBeString); // ['simba', 'nala']
+allNames.map(willBeString); // ['simba', 'nala']
+allNames.map(willBeStringLazily); // ['simba', 'nala']
+allNames.map(willBeStringSomehow); // ['simba', 'nala']
+
+someNames.map(mustBeString); // (throws TypeError('oops'))
+someNames.map(willBeString); // ['simba', 'none']
+someNames.map(willBeStringLazily); // ['simba', 'none, but late']
+someNames.map(willBeStringSomehow); // ['simba', 'oops: [object Object]']
+```
+
 NOTE: Fallback functions are only called when a value does not conform to the type. Also, a fallback value, if any, must also have a conforming type (according to the type guard).
 
 

--- a/README.md
+++ b/README.md
@@ -150,15 +150,44 @@ isArrayOf(Error)([
 ```
 
 
+### Ensuring values are of a certain type
+
+You can use `ensure` to guarantee that a given type is of a specified type.
+
+`ensure` receives a type guard and returns an identity function that returns its argument if it passes the type guard test, or throws a `TypeError` otherwise (optionally, with a custom error message).
+
+Optionally, you can provide a fallback value, getter or mapper with `ensure(guard).orElse`, `ensure(guard).orGet` and `ensure(guard).orMap`, respectively, in case the type doesn't pass the type guard test.
+
+```typescript
+const mustBeString = ensure(isString, 'oops');
+const willBeString = ensure(isString).orElse('none');
+const willBeStringLazily = ensure(isString).orGet(() => 'none, but late');
+const willBeStringSomehow = ensure(isString).orMap(value => `oops: ${String(value)}`);
+
+mustBeString('simba'); // 'simba'
+mustBeString(undefined); // (throws TypeError('oops'))
+
+willBeString('nala'); // 'nala'
+willBeString(null); // 'none'
+
+willBeStringLazily('pumbaa'); // 'pumbaa'
+willBeStringLazily(10); // 'none, but late'
+
+willBeStringSomehow('someone'); // 'someone'
+willBeStringSomehow([someone]); // 'oops: [object Object]'
+```
+
+NOTE: Fallback functions are only called when a value does not conform to the type. Also, a fallback value, if any, must also have a conforming type (according to the type guard).
+
 
 ## Contributing
 
 1. [Fork the repo](https://github.com/SimonAlling/ts-type-guards/fork).
-1. Create your feature branch (`git checkout -b feature/foobar`).
-1. Examine and add your changes (`git diff`, then `git add ...`).
-1. Commit your changes (`git commit -m 'Add some foobar'`).
-1. Push your feature branch (`git push origin feature/foobar`).
-1. [Create a pull request](https://github.com/SimonAlling/ts-type-guards/pulls).
+2. Create your feature branch (`git checkout -b feature/foobar`).
+3. Examine and add your changes (`git diff`, then `git add ...`).
+4. Commit your changes (`git commit -m 'Add some foobar'`).
+5. Push your feature branch (`git push origin feature/foobar`).
+6. [Create a pull request](https://github.com/SimonAlling/ts-type-guards/pulls).
 
 
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -9,6 +9,7 @@ import {
     isNonPrimitive,
     is,
     isLike,
+    ensure,
 } from "../src/index";
 
 const SATISFY = true;
@@ -225,4 +226,26 @@ it("isLike for array of dictionaries", () => {
         shouldSatisfy: [ [], [ { a: "a" } ], [ { a: "a" }, { a: "aa" } ] ],
         shouldNotSatisfy: BASICS.concat([ {}, [ {} ], [ { b: "bbb" } ], [ { a: 5 } ], [ { a: undefined } ] ]),
     });
+});
+
+it("ensure", () => {
+    const message = "NOT VALID";
+
+    expect(ensure(isUndefined)).toBeInstanceOf(Function);
+    expect(ensure(isUndefined).orElse).toBeInstanceOf(Function);
+    expect(ensure(isUndefined).orGet).toBeInstanceOf(Function);
+    expect(ensure(isUndefined).orMap).toBeInstanceOf(Function);
+
+    expect(() => ensure(isUndefined)(null)).toThrowError(TypeError);
+    expect(() => ensure(isUndefined, message)(null)).toThrowError(message);
+    expect(ensure(isString)(message)).toBe(message);
+
+    expect(ensure(isString).orElse(message)('')).toBe('');
+    expect(ensure(isString).orElse(message)(null)).toBe(message);
+
+    expect(ensure(isString).orGet(() => message)('')).toBe('');
+    expect(ensure(isString).orGet(() => message)(null)).toBe(message);
+
+    expect(ensure(isString).orMap(value => `${String(value)}: message`)('')).toBe('');
+    expect(ensure(isString).orMap(value => `${String(value)}: message`)(null)).toBe(`${String(null)}: message`);
 });

--- a/src/ensure.ts
+++ b/src/ensure.ts
@@ -1,0 +1,98 @@
+
+import {
+    TypeGuard,
+    TypeEnforcer,
+} from './types';
+
+function makeEnforcerName<T>(guard: TypeGuard<T>) {
+    return `ensure(${guard.name})`;
+}
+
+function makeEnsurerName<T, F = T>(guard: TypeGuard<T>, type: string, fallback: F) {
+    const maxChars = 16;
+    let fallbackName = '';
+    if (fallback && typeof fallback === 'function') {
+        fallbackName = (fallback as any).name;
+    } else if (typeof fallback === 'string') {
+        fallbackName = `"${fallback.length <= maxChars ? fallback : fallback.slice(0, maxChars)}"`;
+    } else {
+        fallbackName = String(fallback);
+        if (fallbackName.length > maxChars) {
+            fallbackName = fallbackName.slice(0, 16);
+        }
+    }
+    return `${makeEnforcerName(guard)}.${type}(${fallbackName || '?'})`;
+}
+
+function assignName<T>(value: T, name: string) {
+    Object.defineProperty(value, 'name', {
+        value: name,
+        writable: false,
+        configurable: true,
+        enumerable: true,
+    });
+}
+
+/**
+ * Creates a type enforcer.
+ * 
+ * Use `orElse`, `orGet` and `orMap` to create a type ensurer (i.e. that returns
+ * a fallback value instead of throwing TypeError when the value does not
+ * conform) instead.
+ * 
+ * @param guard The type guard to use
+ * @param message An optional error message. Not actually used when a fallback
+ * value is provided.
+ */
+export function ensure<T>(
+    guard: TypeGuard<T>,
+    message?: string | (() => string),
+): TypeEnforcer<T> {
+    const invalidFallbackMessage = 
+        "The fallback value provided is invalid or does not meet the enforcer's type requirements.";
+    const getErrorMessage = () => 
+        typeof message === 'string' ? message
+        : message ? message()
+        : "The value provided is invalid or does not meet the enforcer's type requirements.";
+    function doEnforce<V extends T>(value: V): V;
+    function doEnforce(value: any): never;
+    function doEnforce<V extends T>(value: V): V {
+        if (guard(value)) return value;
+        throw new TypeError(getErrorMessage());
+    }
+    assignName(doEnforce, makeEnforcerName(guard));
+    const enforcer = Object.assign(doEnforce, {
+        orElse<F extends T>(fallback: F) {
+            if (!guard(fallback)) throw new TypeError(invalidFallbackMessage);
+            const ensurer = <V>(value: V): V | F => {
+                if (guard(value)) return value;
+                return fallback;
+            };
+            assignName(doEnforce, makeEnsurerName(guard, 'orElse', fallback));
+            return ensurer;
+        },
+        orGet<F extends T>(fallbackGetter: (() => F)) {
+            if (typeof fallbackGetter !== 'function') throw new TypeError("Invalid fallback getter");
+            const ensurer = <V>(value: V): V | F => {
+                if (guard(value)) return value;
+                const fallback = fallbackGetter();
+                if (!guard(fallback)) throw new TypeError(invalidFallbackMessage);
+                return fallback;
+            };
+            assignName(doEnforce, makeEnsurerName(guard, 'orElse', fallbackGetter));
+            return ensurer;
+        },
+        orMap<F extends T>(fallbackMapper: ((value: any) => F)) {
+            if (typeof fallbackMapper !== 'function') throw new TypeError("Invalid fallback mapper");
+            const ensurer = <V>(value: V): V | F => {
+                if (guard(value)) return value;
+                const fallback = fallbackMapper(value);
+                if (!guard(fallback)) throw new TypeError(invalidFallbackMessage);
+                return fallback;
+            };
+            assignName(doEnforce, makeEnsurerName(guard, 'orElse', fallbackMapper));
+            return ensurer;
+        },
+    });
+    return enforcer;
+}

--- a/src/ensure.ts
+++ b/src/ensure.ts
@@ -68,7 +68,7 @@ export function ensure<T>(
                 if (guard(value)) return value;
                 return fallback;
             };
-            assignName(doEnforce, makeEnsurerName(guard, 'orElse', fallback));
+            assignName(ensurer, makeEnsurerName(guard, 'orElse', fallback));
             return ensurer;
         },
         orGet<F extends T>(fallbackGetter: (() => F)) {
@@ -79,7 +79,7 @@ export function ensure<T>(
                 if (!guard(fallback)) throw new TypeError(invalidFallbackMessage);
                 return fallback;
             };
-            assignName(doEnforce, makeEnsurerName(guard, 'orElse', fallbackGetter));
+            assignName(ensurer, makeEnsurerName(guard, 'orElse', fallbackGetter));
             return ensurer;
         },
         orMap<F extends T>(fallbackMapper: ((value: any) => F)) {
@@ -90,7 +90,7 @@ export function ensure<T>(
                 if (!guard(fallback)) throw new TypeError(invalidFallbackMessage);
                 return fallback;
             };
-            assignName(doEnforce, makeEnsurerName(guard, 'orElse', fallbackMapper));
+            assignName(ensurer, makeEnsurerName(guard, 'orElse', fallbackMapper));
             return ensurer;
         },
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ export {
     primitive,
     Classy,
     TypeGuard,
+    TypeEnforcer,
+    TypeEnsurer,
 } from "./types";
 
 export {
@@ -42,3 +44,7 @@ export {
     only,
     onlyLike,
 } from "./only";
+
+export {
+    ensure,
+} from './ensure';

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,3 +3,28 @@ export type primitive = boolean | number | string | symbol | null | undefined;
 export type Classy<T> = Function & { prototype: T };
 
 export type TypeGuard<T> = (x: any) => x is T;
+
+/**
+ * Enforces a value to be of a specific type by means of a type guard.
+ */
+export interface TypeEnforcer<T> {
+    readonly name: string;
+    <V extends T>(value: V): V;
+    (value: any): never;
+
+    orElse<F extends T>(value: F): TypeEnsurer<T, F>;
+
+    orGet<F extends T>(getter: (() => F)): TypeEnsurer<T, F>;
+
+    orMap<F extends T = T>(mapper: ((value: any) => T | F)): TypeEnsurer<T, F>;
+}
+
+/**
+ * Ensures a value to be of a specific type by means of a type guard and a
+ * fallback value.
+ */
+export interface TypeEnsurer<T, F extends T = T> {
+    readonly name: string;
+    <V extends T>(value: V): V;
+    (value: any): F;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type TypeGuard<T> = (x: any) => x is T;
  */
 export interface TypeEnforcer<T> {
     readonly name: string;
+    readonly hasFallback?: false;
     <V extends T>(value: V): V;
     (value: any): never;
 
@@ -25,6 +26,7 @@ export interface TypeEnforcer<T> {
  */
 export interface TypeEnsurer<T, F extends T = T> {
     readonly name: string;
+    readonly hasFallback: true;
     <V extends T>(value: V): V;
     (value: any): F;
 }


### PR DESCRIPTION
This PR adds a new functionality: type enforcers and type ensurers.

Type enforcers is a new concept to the library: it is an identity function that guarantees that some value is of a type described by a type guard. If the value does not conform, a `TypeError` is thrown.

Type ensurers are essentially type enforcers, but they try to avoid throwing exceptions by providing a fallback mechanism. Three fallback mechanisms are given: by value, by _getter_ (e.g. lazily retrieved) or by value mapping (think `Array.map`).

Type enforcers and ensurers were introduced in order to work with guards and guard chains (e.g. `ensure(guard(isString).or(isUndefined)).orElse(undefined)`, please refer to my other PR for details on `guard`), and to provide a more generic filtering (e.g. `only`-like) mechanism (I still plan to implement this other mechanism in the near future :).

Please see the README and the tests folder for more examples.

Two PRs down, two to go.