### PR TITLE
feat: predicate filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,11 @@ function isArrayOfX(guard) {
 
 #### Arrays and Readonly-ness
 
-`isArrayOfAll` and `isArrayOfSome` are typed so that they return a curried type guard that preserves the readonly-ness of an eventual readonly array input, if any.
+`isArrayOfAll` is typed so that it returns a curried type guard that preserves the readonly-ness of an eventual readonly array input, if any.
 
 In other words: if the input value is statically known to be a readonly array, the return type of the curried type guard is `xs is ReadonlyArray<T>`; otherwise, the return type is `xs is T[]`.
 
-If you want to force the curried type guard to have an exclusively readonly array type check (i.e. always `xs is ReadonlyArray<T>`), use `isReadonlyArrayOfAll` and `isReadonlyArrayOfSome` instead. Note, however, that the input value is still checked **only** for `is(Array)`; neither [freezing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze) nor [sealing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal) checks are performed.
+If you want to force the curried type guard to have an exclusively readonly array type check (i.e. always `xs is ReadonlyArray<T>`), use `isReadonlyArrayOfAll` instead. Note, however, that the input value is still checked **only** for `is(Array)`; neither [freezing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze) nor [sealing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal) checks are performed.
 
 ```typescript
 declare const animals: any;

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -9,6 +9,10 @@ import {
     isNonPrimitive,
     is,
     isLike,
+    TypeGuard,
+    onlyIf,
+    isArrayOfAll,
+    isArrayOfSome,
 } from "../src/index";
 
 const SATISFY = true;
@@ -224,5 +228,45 @@ it("isLike for array of dictionaries", () => {
     check(isLike([ { a: "aaa" } ]), {
         shouldSatisfy: [ [], [ { a: "a" } ], [ { a: "a" }, { a: "aa" } ] ],
         shouldNotSatisfy: BASICS.concat([ {}, [ {} ], [ { b: "bbb" } ], [ { a: 5 } ], [ { a: undefined } ] ]),
+    });
+});
+
+it("onlyIf", () => {
+    const singles: TypeGuard<any>[] = [ isUndefined, isNull, isSymbol, is(Function) ];
+    for (let predicate of singles) {
+        const filtered = onlyIf(predicate)(BASICS);
+        expect(filtered.length).toBe(1);
+        expect(predicate(filtered[0])).toSatisfy;
+    }
+    const duplicates: TypeGuard<any>[] = [ isBoolean, isNumber, isString ];
+    for (let predicate of duplicates) {
+        const filtered = onlyIf(predicate)(BASICS);
+        expect(filtered.length).toBe(2);
+        for (let value of filtered) {
+            expect(predicate(value)).toSatisfy;
+        }
+    }
+});
+
+it("isArrayOfAll", () => {
+    check(isArrayOfAll(isString), {
+        shouldSatisfy: [ [], [ "" ], [ "", 'foo' ] ],
+        shouldNotSatisfy: [ 
+            undefined, null, true, false, 0, 1, "", "foo", Symbol(), _ => 5, {}, Animal, someone,
+            [undefined], [null], [true], [false], [0], [1], [Symbol()], [_ => 5], [[]], [{}], [Animal], [someone],
+            [undefined, null], [true, false, 0], [1, Symbol(), _ => 5], [[], {}], [Animal, someone],
+            ["", _ => 5], ["", [""]],
+        ],
+    });
+});
+
+it("isArrayOfSome", () => {
+    check(isArrayOfSome(isString), {
+        shouldSatisfy: [ [ "" ], [ "", 'foo' ], [ "", Symbol() ], [ [ "" ], ""] ],
+        shouldNotSatisfy: [ 
+            undefined, null, true, false, 0, 1, "", "foo", Symbol(), _ => 5, [], {}, Animal, someone,
+            [undefined], [null], [true], [false], [0], [1], [Symbol()], [_ => 5], [[]], [{}], [Animal], [someone],
+            [undefined, null], [true, false, 0], [1, Symbol(), _ => 5], [[], {}], [Animal, someone],
+        ],
     });
 });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -12,7 +12,6 @@ import {
     TypeGuard,
     onlyIf,
     isArrayOfAll,
-    isArrayOfSome,
 } from "../src/index";
 
 const SATISFY = true;
@@ -256,17 +255,6 @@ it("isArrayOfAll", () => {
             [undefined], [null], [true], [false], [0], [1], [Symbol()], [_ => 5], [[]], [{}], [Animal], [someone],
             [undefined, null], [true, false, 0], [1, Symbol(), _ => 5], [[], {}], [Animal, someone],
             ["", _ => 5], ["", [""]],
-        ],
-    });
-});
-
-it("isArrayOfSome", () => {
-    check(isArrayOfSome(isString), {
-        shouldSatisfy: [ [ "" ], [ "", 'foo' ], [ "", Symbol() ], [ [ "" ], ""] ],
-        shouldNotSatisfy: [ 
-            undefined, null, true, false, 0, 1, "", "foo", Symbol(), _ => 5, [], {}, Animal, someone,
-            [undefined], [null], [true], [false], [0], [1], [Symbol()], [_ => 5], [[]], [{}], [Animal], [someone],
-            [undefined, null], [true, false, 0], [1, Symbol(), _ => 5], [[], {}], [Animal, someone],
         ],
     });
 });

--- a/src/array.ts
+++ b/src/array.ts
@@ -1,4 +1,4 @@
-import { primitive, Classy } from "./types";
+import { primitive, Classy, TypeGuard, ArrayTypeGuard, ReadonlyArrayTypeGuard } from "./types";
 import { isBoolean, isNumber, isString, isSymbol, isNull, isUndefined, isPrimitive, isNonPrimitive, is, isLike } from "./is";
 
 export function isArrayOfBooleans(x: any): x is boolean[] {
@@ -39,4 +39,20 @@ export function isArrayOf<T>(type: Classy<T>): (xs: any) => xs is T[] {
 
 export function isArrayOfLike<T>(reference: T): (x: any) => x is T[] {
     return (x: any): x is T[] => is(Array)(x) && x.every(isLike(reference));
+}
+
+export function isArrayOfAll<T>(guard: TypeGuard<T>): ArrayTypeGuard<T> {
+    return (xs: any): xs is T[] => is(Array)(xs) && xs.every(guard);
+}
+
+export function isArrayOfSome<T>(guard: TypeGuard<T>): ArrayTypeGuard<T> {
+    return (xs: any): xs is T[] => is(Array)(xs) && xs.some(guard);
+}
+
+export function isReadonlyArrayOfAll<T>(guard: TypeGuard<T>): ReadonlyArrayTypeGuard<T> {
+    return isArrayOfAll(guard);
+}
+
+export function isReadonlyArrayOfSome<T>(guard: TypeGuard<T>): ReadonlyArrayTypeGuard<T> {
+    return isArrayOfSome(guard)
 }

--- a/src/array.ts
+++ b/src/array.ts
@@ -45,14 +45,6 @@ export function isArrayOfAll<T>(guard: TypeGuard<T>): ArrayTypeGuard<T> {
     return (xs: any): xs is T[] => is(Array)(xs) && xs.every(guard);
 }
 
-export function isArrayOfSome<T>(guard: TypeGuard<T>): ArrayTypeGuard<T> {
-    return (xs: any): xs is T[] => is(Array)(xs) && xs.some(guard);
-}
-
 export function isReadonlyArrayOfAll<T>(guard: TypeGuard<T>): ReadonlyArrayTypeGuard<T> {
     return isArrayOfAll(guard);
-}
-
-export function isReadonlyArrayOfSome<T>(guard: TypeGuard<T>): ReadonlyArrayTypeGuard<T> {
-    return isArrayOfSome(guard)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,9 +31,7 @@ export {
     isArrayOf,
     isArrayOfLike,
     isArrayOfAll,
-    isArrayOfSome,
     isReadonlyArrayOfAll,
-    isReadonlyArrayOfSome,
 } from "./array";
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ export {
     primitive,
     Classy,
     TypeGuard,
+    ArrayTypeGuard,
+    ReadonlyArrayTypeGuard,
 } from "./types";
 
 export {
@@ -28,6 +30,10 @@ export {
     isArrayOfObjects,
     isArrayOf,
     isArrayOfLike,
+    isArrayOfAll,
+    isArrayOfSome,
+    isReadonlyArrayOfAll,
+    isReadonlyArrayOfSome,
 } from "./array";
 
 export {
@@ -41,4 +47,5 @@ export {
     onlyObjects,
     only,
     onlyLike,
+    onlyIf,
 } from "./only";

--- a/src/only.ts
+++ b/src/only.ts
@@ -1,4 +1,4 @@
-import { primitive, Classy } from "./types";
+import { primitive, Classy, TypeGuard } from "./types";
 import { isBoolean, isNumber, isString, isSymbol, isNull, isUndefined, isPrimitive, isNonPrimitive, is, isLike } from "./is";
 
 export function onlyBooleans(xs: any[]): boolean[] {
@@ -39,4 +39,8 @@ export function only<T>(type: Classy<T>): (xs: any[]) => T[] {
 
 export function onlyLike<T>(reference: T): (xs: any[]) => T[] {
     return (xs: any[]): T[] => xs.filter(isLike(reference));
+}
+
+export function onlyIf<T>(guard: TypeGuard<T>): (xs: ReadonlyArray<any>) => T[] {
+    return (xs: any[]): T[] => xs.filter(guard);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,3 +3,13 @@ export type primitive = boolean | number | string | symbol | null | undefined;
 export type Classy<T> = Function & { prototype: T };
 
 export type TypeGuard<T> = (x: any) => x is T;
+
+export interface ArrayTypeGuard<T> {
+    (xs: any[]): xs is T[];
+    (xs: ReadonlyArray<any>): xs is ReadonlyArray<T>;
+    (xs: any): xs is T[];
+}
+
+export interface ReadonlyArrayTypeGuard<T> {
+    (xs: any): xs is ReadonlyArray<T>;
+}


### PR DESCRIPTION
This PR introduces a slight modification of the `isArrayOf` and `only` themes. Two new functions are introduced as more generic alternatives to the primitive and classy type guards:

- `isArrayOfAll` (and its readonly counterpart `isReadonlyArrayOfAll`) is the same as `isArrayOf` but receives type guards instead of classy/like type information.
- `onlyIf` is the same as `only`, but receives type guards instead of classy/like type information, just like `isArrayOfAll`.

With them, one can abstract away primitive or classy-type-specific type guards by depending solely on the `TypeGuard` concept.

This feature plays (or at least I expect that it will play) rather well with guard chaining; instead of having mono-typed array checks, e.g. `isArrayOfStrings(x) || isArrayOfNumbers(x)`, one can check for arrays of diverse types, with the added possibility of single evaluation of the operand and a single curried type guard, e.g. `isArrayOfAll(guard(isString).or(isNumber))(x)` (typed as `x is string | number`).

In the future, I will submit a new PR that does interface checking by means of an interface descriptor, and the predicate filtering functionality will play a vital role in enabling a more flexible filtering in cases where a classy type is not available at runtime (e.g. when using only interfaces).

One PR remaining! :D